### PR TITLE
Fix layout detector attribute and node ID increment

### DIFF
--- a/src/s2chunking/__init__.py
+++ b/src/s2chunking/__init__.py
@@ -1,4 +1,8 @@
-from .s2_chunker import StructuralSemanticChunker, generate_nodes, generate_edges, format_clusters
+from .s2_chunker import StructuralSemanticChunker, format_clusters
 from .layout_deter import LayoutDetector
 
-__all__ = ['StructuralSemanticChunker', 'generate_nodes', 'generate_edges', 'format_clusters', 'LayoutDetector']
+__all__ = [
+    'StructuralSemanticChunker',
+    'format_clusters',
+    'LayoutDetector',
+]

--- a/src/s2chunking/layout_deter.py
+++ b/src/s2chunking/layout_deter.py
@@ -16,7 +16,8 @@ class LayoutDetector:
         local_model_path: Optional[str] = None,
         device: str = "cuda" if torch.cuda.is_available() else "cpu"
     ):
-        self.image = image_path
+        # Store the path to the image that will be processed
+        self.image_path = image_path
         self.device = device
         self.repo_id = repo_id
         self.weights_folder = weights_folder
@@ -58,7 +59,7 @@ class LayoutDetector:
         """Detect layout elements in an image using YOLO."""
         try:
             # Load image
-            image = cv2.imread(self.imgae_path)
+            image = cv2.imread(self.image_path)
             if image is None:
                 raise ValueError(f"Unable to load image from {self.image_path}")
     

--- a/src/s2chunking/s2_chunker.py
+++ b/src/s2chunking/s2_chunker.py
@@ -135,12 +135,16 @@ class StructuralSemanticChunker(BaseModel):
         try:
             all_nodes = []
             all_edges = []
+            global_id_counter = 1
             for page_number, image_path in enumerate(image_paths, start=1):
                 self.layout_detector = LayoutDetector(image_path=image_path)
                 layout_info = self.layout_detector.detect_layout()
 
-                nodes = self._generate_nodes_from_layout(layout_info, page_number)
+                nodes = self._generate_nodes_from_layout(
+                    layout_info, page_number, start_global_id=global_id_counter
+                )
                 all_nodes.extend(nodes)
+                global_id_counter += len(nodes)
 
                 edges = self._generate_edges(nodes)
                 all_edges.extend(edges)
@@ -150,7 +154,9 @@ class StructuralSemanticChunker(BaseModel):
             print(f"Error in chunk_from_images: {e}")
             return {}
 
-    def _generate_nodes_from_layout(self, layout_info: List[Dict], page_number: int) -> List[Dict]:
+    def _generate_nodes_from_layout(
+        self, layout_info: List[Dict], page_number: int, *, start_global_id: int = 1
+    ) -> List[Dict]:
         """
         Generate nodes from layout detection results for a specific page.
         Args:
@@ -163,11 +169,11 @@ class StructuralSemanticChunker(BaseModel):
         nodes = []
         for i, item in enumerate(layout_info):
             nodes.append({
-                "global_id": len(nodes) + 1,
+                "global_id": start_global_id + i,
                 "page": page_number,
-                "local_id": i + 1, 
+                "local_id": i + 1,
                 "bbox": item["bbox"],
-                "text": item["label"] 
+                "text": item["label"],
             })
         return nodes
 


### PR DESCRIPTION
## Summary
- fix attribute name for reading images in LayoutDetector
- export only valid helpers in module init
- ensure unique global IDs across pages when generating nodes

## Testing
- `python -m py_compile src/s2chunking/*.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

